### PR TITLE
Profile Request Returns 404 Bug-Fix

### DIFF
--- a/data/auth.js
+++ b/data/auth.js
@@ -21,7 +21,7 @@ export function register(user) {
 }
 
 export function getUserProfile() {
-  return fetchWithResponse('my-profile', {
+  return fetchWithResponse('profile', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bangazon-client",
+  "name": "bangazon-client-bangazon-team-1-client",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -1809,13 +1809,23 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001282",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
-      "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001600",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
+      "integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -6721,9 +6731,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001282",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
-      "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg=="
+      "version": "1.0.30001600",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001600.tgz",
+      "integrity": "sha512-+2S9/2JFhYmYaDpZvo0lKkfvuKIglrx68MwOBqMGHhQsNkLjB5xtc/TGoEPs+MxjSyN/72qer2g97nzR641mOQ=="
     },
     "chalk": {
       "version": "2.4.2",


### PR DESCRIPTION
This PR solves the issue of the client incorrectly making a request to the `/my-profile` view, rather than the `/profile` view.

## Changes

- `/data/auth.js` - Changed the `getUserProfile()` url from `/my-profile` to `/profile`


## Requests / Responses

In order to manually test the server response, you can use the following:

**Request**

- GET `/profile`
<h6>NOTE: You can find this request template within Postman under "/Bangazon Python API/Profile/User profile".</h6>

**Response**

- HTTP/1.1 200 OK

This should return the specified user's profile info. For example:

```json
{
    "id": 7,
    "url": "http://localhost:8000/customers/7",
    "user": {
        "first_name": "Brenda",
        "last_name": "Long",
        "email": "brenda@brendalong.com"
    },
    "phone_number": "555-1212",
    "address": "100 Indefatiguable Way",
    "payment_types": [
        {
            "id": 3,
            "deleted": null,
            "deleted_by_cascade": false,
            "merchant_name": "Visa",
            "account_number": "fj0398fjw0g89434",
            "expiration_date": "2020-03-01",
            "create_date": "2019-03-11",
            "customer": 7
        }
    ],
    "recommends": []
}
```

## Testing

To test this code, make sure that you are in the `bugfix/profile-not-found` branch on your client-side, and the `development` branch on your API-side.
- [x] Start the server
- [x] Start the client, and open `http://localhost:3000` in your browser
- [x] Log in, if necessary
- [x] Click the "Profile" button in the navbar, to navigate to the **Profile** page (`/profile`).
- [x] In your devtools, in the _network_ tab, when you load the page, you should see a GET request being made to `/profile`.
- [x] Verify that this request returns an HTTP/1.1 200 OK response code, with the profile info in the response body.
- As an example of what you can expect to see, please refer to the `json` above, and the image below:

<img width="826" alt="Screen Shot" src="https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/assets/147445675/a6d50832-41a2-443b-af8c-27158468c861">

## Unrelated Changes

- update to the `package-lock.json`
