### PR TITLE
Incorrect Rating Request Bug-Fix

### DIFF
--- a/components/product/detail.js
+++ b/components/product/detail.js
@@ -46,7 +46,7 @@ export function Detail({ product, like, unlike }) {
         <div className="tile is-parent">
           <article className="tile is-child">
             <figure className="image is-4by3">
-              <img src="https://bulma.io/images/placeholders/640x480.png"></img>
+              <img src={product.image_path}></img>
             </figure>
           </article>
         </div>

--- a/components/rating/detail.js
+++ b/components/rating/detail.js
@@ -3,18 +3,12 @@ import { rateProduct } from '../../data/products'
 import { RatingsContainer } from './container'
 import { Header } from './header'
 
-export function Ratings({ average_rating, refresh, ratings = [], number_purchased, likes = [] }) {
-  const [productId, setProductId] = useState(0)
+export function Ratings({ average_rating, refresh, ratings = [], number_purchased, likes = [], productId }) {
   const saveRating = (newRating) => {
     rateProduct(productId, newRating).then(refresh)
 
   }
 
-  useEffect(() => {
-    if (ratings.length) {
-      setProductId(ratings[0].product)
-    }
-  }, [ratings])
 
   return (
     <div className="tile is-ancestor is-flex-wrap-wrap">

--- a/pages/products/[id]/index.js
+++ b/pages/products/[id]/index.js
@@ -43,6 +43,7 @@ export default function ProductDetail() {
           ratings={product.ratings}
           average_rating={product.average_rating}
           likes={product.likes}
+          productId={id}
         />
       </div>
     </div>


### PR DESCRIPTION
This PR solves the issue of the client incorrectly always making a request to `/products/0/rate-product` when rating a product, rather than using the correct `product`'s `id` in the request url.

## Changes

- `/pages/products/[id]/index.js`
    - passed down the `productId` prop to the `Ratings` component from the `ProductDetail` component
- `/components/rating/detail.js`
    - removed the bad logic that was causing the `productId` to always be set to `0`, in favor of the new passed-down `productId` prop

### Unrelated Changes
- `/components/product/detail.js`
    - fixed incorrect image path

## Testing

To test this code, make sure that you are in the most recent versions of the `bugfix/bad-rating-url` branch on your client-side, and the `development` branch on your API-side.

- [x] Start the server
- [x] Start the client, and open `http://localhost:3000` in your browser
- [x] Navigate to either the **Home** page (`/`) or the **Products** page (`/products`)
- [x] Click on a product's name/price to be taken to the details for that product (`/products/n`)
- [x] Once there, select any amount of stars 1-5 on the bottom-left of the page
- [x] Optionally, you can type a review as well in the "Add your review" textbox
- [x] After you have selected some amount of stars, click on the "**Post Rating**" button
    - _You may notice that there is no feedback that the rating has been posted (such as the textbox being cleared). This will most likely be fixed in a future ticket._
- [x] In your **network** tab, verify that the request to `rate-product` was successful. There should be a 201 Created status code, as well as a request payload that looks something like this:
```json
{ "score": 5, "review": "Lorem ipsum..." }
``` 
- See below for what this process should look like:

![Screen Recording](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/assets/147445675/2d4b9955-7799-47c2-8cfd-92883185337b)

## Related Issues

- #15