### PR TITLE
Missing Product Detail Information Bug-Fix

### DIFF
--- a/components/rating/card.js
+++ b/components/rating/card.js
@@ -5,7 +5,7 @@ export function RatingCard({ rating }) {
     <div className="tile is-child">
       <article className="media box is-align-items-center">
         <figure className="media-left">
-          <Rating initialValue={rating.score} readonly={true} />
+          <Rating initialValue={rating.rating} readonly={true} />
         </figure>
         <div className="media-content">
           <div className="content">

--- a/pages/products/[id]/index.js
+++ b/pages/products/[id]/index.js
@@ -39,7 +39,7 @@ export default function ProductDetail() {
         <Detail product={product} like={like} unlike={unlike}/>
         <Ratings
           refresh={refresh}
-          number_purchased={product.number_purchased}
+          number_purchased={product.number_sold}
           ratings={product.ratings}
           average_rating={product.average_rating}
           likes={product.likes}


### PR DESCRIPTION
This PR solves the issue of the **Product Details** page not properly displaying the correct information.

## Changes

- `/components/rating/card.js`
    - changed attempting the access of `.score` to `.rating`
- `/pages/products/[id]/index.js`
    - changed attempting the access of `.number_purchased` to `.number_sold`

## Testing

To test this code, make sure that you are in the most recent versions of the `bugfix/detail-info` branch on your client-side, and the `development` branch on your API-side.

- [x] Start the server
- [x] Start the client, and open `http://localhost:3000` in your browser
- [x] Navigate to either the **Home** page (`/`) or the **Products** page (`/products`)
- [x] Click on a product's name/price to be taken to the details for that product (`/products/n`)
- Once you are viewing the **Product Details** page, you will need to verify the following:
  - [x] The "**AVG. RATING**" appears correctly
  - [x] The "**# OF REVIEWS**" appears correctly
  - [x] The "**PURCHASED**" appears correctly
  - [x] The previous ratings are all listed correctly at the bottom, with the proper rating and review.
  - _Note that the "**LIKES**" will currently always be `0`, because this feature is not yet implemented._
- Below are 2 examples of what you can expect to see.

`/products/131`:

<img width="759" alt="Screen Shot" src="https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/assets/147445675/35822add-32f1-44cf-b717-1bfbdb95daee">

&#x200B;

`/products/50`:

![Screen Recording](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/assets/147445675/8c9b7456-351e-405e-a1f3-fb0186b25985)
