### PR TITLE
Feature: Create a store

### DIFF
--- a/data/fetcher.js
+++ b/data/fetcher.js
@@ -15,6 +15,13 @@ const checkErrorJson = (res) => {
   }
 }
 
+const checkCreateErrorJson = (res) => {
+  if (res.status !== 201) {
+    throw Error(res.status);
+  } else {
+    return res.json()
+  }
+}
 
 const catchError = (err) => {
   if (err.message === '401') {
@@ -27,6 +34,10 @@ const catchError = (err) => {
 
 export const fetchWithResponse = (resource, options) => fetch(`${API_URL}/${resource}`, options)
   .then(checkErrorJson)
+  .catch(catchError)
+
+  export const createWithResponse = (resource, options) => fetch(`${API_URL}/${resource}`, options)
+  .then(checkCreateErrorJson)
   .catch(catchError)
 
 export const fetchWithoutResponse = (resource, options) => fetch(`${API_URL}/${resource}`, options)

--- a/data/stores.js
+++ b/data/stores.js
@@ -1,59 +1,59 @@
-import { fetchWithResponse, fetchWithoutResponse } from './fetcher'
+import { createWithResponse, fetchWithResponse, fetchWithoutResponse } from "./fetcher"
 
 export function getStores() {
-  return fetchWithResponse('stores', {
+  return fetchWithResponse("stores", {
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`
-    }
+      Authorization: `Token ${localStorage.getItem("token")}`,
+    },
   })
 }
 
 export function getStoreById(id) {
   return fetchWithResponse(`stores/${id}`, {
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`
-    }
+      Authorization: `Token ${localStorage.getItem("token")}`,
+    },
   })
 }
 
-export function addStore(store) {
-  return fetchWithResponse(`stores`, {
-    method: 'POST',
+export async function addStore(store) {
+  return createWithResponse(`stores`, {
+    method: "POST",
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`,
-      'Content-Type': 'application/json'
+      Authorization: `Token ${localStorage.getItem("token")}`,
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify(store)
+    body: JSON.stringify(store),
   })
 }
 
 export function editStore(store) {
   return fetchWithoutResponse(`stores/${store.id}`, {
-    method: 'PUT',
+    method: "PUT",
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`,
-      'Content-Type': 'application/json'
+      Authorization: `Token ${localStorage.getItem("token")}`,
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify(store)
+    body: JSON.stringify(store),
   })
 }
 
 export function favoriteStore(storeId) {
   return fetchWithoutResponse(`stores/${storeId}/favorite`, {
-    method: 'POST',
+    method: "POST",
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`,
-      'Content-Type': 'application/json'
+      Authorization: `Token ${localStorage.getItem("token")}`,
+      "Content-Type": "application/json",
     },
   })
 }
 
 export function unfavoriteStore(storeId) {
   return fetchWithoutResponse(`stores/${storeId}/unfavorite`, {
-    method: 'DELETE',
+    method: "DELETE",
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`,
-      'Content-Type': 'application/json'
+      Authorization: `Token ${localStorage.getItem("token")}`,
+      "Content-Type": "application/json",
     },
   })
 }


### PR DESCRIPTION
Changes to navigate to the new store page after a store has been created.
Closes #14 

## Changes

- stores.js line 20: changed fetchWithResponse to createWithResponse
- fetcher.js line 18: added checkCreateErrorJson and line 39: added createWithResponse function

## Testing

Description of how to test code...

- [x] Start the client, and open http://localhost:3000 in your browser.
- [x] Make sure API debugger is running and API side is updated with most recent store module functionality
- [x] Login and navigate to "Interested in selling?"
- [x] Create a new store
- [x] After filling the form and saving, the page should navigate to your newly create store.