### PR TITLE
Bug: Completing an order

### DIFF
--- a/data/orders.js
+++ b/data/orders.js
@@ -1,7 +1,7 @@
 import { fetchWithResponse } from './fetcher'
 
 export function getCart() {
-  return fetchWithResponse('cårt', {
+  return fetchWithResponse('cart', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`
     }
@@ -17,12 +17,12 @@ export function getOrders() {
 }
 
 export function completeCurrentOrder(orderId, paymentTypeId) {
-  return fetchWithResponse(`orders/${orderId}/complete`, {
+  return fetchWithResponse(`orders/${orderId}`, {
     method: 'PUT',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({paymentTypeId})
+    body: JSON.stringify(paymentTypeId)
   })
 }

--- a/data/payment-types.js
+++ b/data/payment-types.js
@@ -9,7 +9,7 @@ export function getPaymentTypes() {
 }
 
 export function addPaymentType(paymentType) {
-  return fetchWithResponse(`payment-types`, {
+  return fetchWithResponse(`paymenttypes`, {
     method: 'POST',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
@@ -20,7 +20,7 @@ export function addPaymentType(paymentType) {
 }
 
 export function deletePaymentType(id) {
-  return fetchWithoutResponse(`payment-types/${id}`, {
+  return fetchWithoutResponse(`paymenttypes/${id}`, {
     method: 'DELETE',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -1,13 +1,13 @@
-import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
-import CardLayout from '../components/card-layout'
-import Layout from '../components/layout'
-import Navbar from '../components/navbar'
-import CartDetail from '../components/order/detail'
-import CompleteFormModal from '../components/order/form-modal'
-import { completeCurrentOrder, getCart } from '../data/orders'
-import { getPaymentTypes } from '../data/payment-types'
-import { removeProductFromOrder } from '../data/products'
+import { useRouter } from "next/router"
+import { useEffect, useState } from "react"
+import CardLayout from "../components/card-layout"
+import Layout from "../components/layout"
+import Navbar from "../components/navbar"
+import CartDetail from "../components/order/detail"
+import CompleteFormModal from "../components/order/form-modal"
+import { completeCurrentOrder, getCart } from "../data/orders"
+import { getPaymentTypes } from "../data/payment-types"
+import { removeProductFromOrder } from "../data/products"
 
 export default function Cart() {
   const [cart, setCart] = useState({})
@@ -16,7 +16,7 @@ export default function Cart() {
   const router = useRouter()
 
   const refresh = () => {
-    getCart().then(cartData => {
+    getCart().then((cartData) => {
       if (cartData) {
         setCart(cartData)
       }
@@ -25,7 +25,7 @@ export default function Cart() {
 
   useEffect(() => {
     refresh()
-    getPaymentTypes().then(paymentData => {
+    getPaymentTypes().then((paymentData) => {
       if (paymentData) {
         setPaymentTypes(paymentData)
       }
@@ -33,7 +33,9 @@ export default function Cart() {
   }, [])
 
   const completeOrder = (paymentTypeId) => {
-    completeCurrentOrder(cart.id, paymentTypeId).then(() => router.push('/my-orders'))
+    const payment = { payment_type: paymentTypeId }
+    completeCurrentOrder(cart.id, payment)
+      .then(() => router.push("/my-orders"))
   }
 
   const removeProduct = (productId) => {
@@ -51,7 +53,9 @@ export default function Cart() {
       <CardLayout title="Your Current Order">
         <CartDetail cart={cart} removeProduct={removeProduct} />
         <>
-          <a className="card-footer-item" onClick={() => setShowCompleteForm(true)}>Complete Order</a>
+          <a className="card-footer-item" onClick={() => setShowCompleteForm(true)}>
+            Complete Order
+          </a>
           <a className="card-footer-item">Delete Order</a>
         </>
       </CardLayout>

--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -22,7 +22,6 @@ export default function Orders() {
             const paymentTypeData = await paymentTypeRes.json()
             return { ...order, payment_type: paymentTypeData }
           } catch (error) {
-            console.error(error)
             return { ...order, payment_type: null } // or handle error differently
           }
         })
@@ -30,18 +29,17 @@ export default function Orders() {
         Promise.all(fetchPaymentTypes).then((ordersWithData) => {
           const ordersWithPaymentTypes = ordersWithData.filter((order) => order.paymentType !== null)
           const ordersDataTotal = ordersWithPaymentTypes.map((order) => {
-            let total = 0;
+            let total = 0
             if (order.lineitems) {
               for (const lineItem of order.lineitems) {
-                total += lineItem.product.price;
+                total += lineItem.product.price
               }
             }
             return {
               ...order,
               total: total.toFixed(2),
-            };
-          });
-          console.log(ordersDataTotal)
+            }
+          })
           setOrders(ordersDataTotal)
         })
       }

--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -1,17 +1,18 @@
-import { useEffect, useState } from 'react'
-import CardLayout from '../components/card-layout'
-import Layout from '../components/layout'
-import Navbar from '../components/navbar'
-import Table from '../components/table'
-import { getOrders } from '../data/orders'
+import { useEffect, useState } from "react"
+import CardLayout from "../components/card-layout"
+import Layout from "../components/layout"
+import Navbar from "../components/navbar"
+import Table from "../components/table"
+import { getOrders } from "../data/orders"
 
 export default function Orders() {
   const [orders, setOrders] = useState([])
-  const headers = ['Order Date', 'Total', 'Payment Method']
+  const headers = ["Order Date", "Total", "Payment Method"]
 
   useEffect(() => {
-    getOrders().then(ordersData => {
+    getOrders().then((ordersData) => {
       if (ordersData) {
+        console.log(ordersData)
         setOrders(ordersData)
       }
     })
@@ -21,15 +22,13 @@ export default function Orders() {
     <>
       <CardLayout title="Your Orders">
         <Table headers={headers}>
-          {
-            orders.map((order) => (
-              <tr key={order.id}>
-                <td>{order.completed_on}</td>
-                <td>${order.total}</td>
-                <td>{order.payment_type?.obscured_num}</td>
-              </tr>
-            ))
-          }
+          {orders.map((order) => (
+            <tr key={order.id}>
+              <td>{order.completed_on}</td>
+              <td>${order.total}</td>
+              <td>{order.payment_type?.obscured_num}</td>
+            </tr>
+          ))}
         </Table>
         <></>
       </CardLayout>

--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -4,6 +4,7 @@ import Layout from "../components/layout"
 import Navbar from "../components/navbar"
 import Table from "../components/table"
 import { getOrders } from "../data/orders"
+import { fetchWithResponse } from "../data/fetcher"
 
 export default function Orders() {
   const [orders, setOrders] = useState([])
@@ -12,8 +13,37 @@ export default function Orders() {
   useEffect(() => {
     getOrders().then((ordersData) => {
       if (ordersData) {
-        console.log(ordersData)
-        setOrders(ordersData)
+        const fetchPaymentTypes = ordersData.map(async (order) => {
+          try {
+            const paymentTypeRes = await fetch(order.payment_type)
+            if (!paymentTypeRes.ok) {
+              throw new Error(`Failed to fetch payment type for order ${order.id}`)
+            }
+            const paymentTypeData = await paymentTypeRes.json()
+            return { ...order, payment_type: paymentTypeData }
+          } catch (error) {
+            console.error(error)
+            return { ...order, payment_type: null } // or handle error differently
+          }
+        })
+
+        Promise.all(fetchPaymentTypes).then((ordersWithData) => {
+          const ordersWithPaymentTypes = ordersWithData.filter((order) => order.paymentType !== null)
+          const ordersDataTotal = ordersWithPaymentTypes.map((order) => {
+            let total = 0;
+            if (order.lineitems) {
+              for (const lineItem of order.lineitems) {
+                total += lineItem.product.price;
+              }
+            }
+            return {
+              ...order,
+              total: total.toFixed(2),
+            };
+          });
+          console.log(ordersDataTotal)
+          setOrders(ordersDataTotal)
+        })
       }
     })
   }, [])
@@ -24,9 +54,9 @@ export default function Orders() {
         <Table headers={headers}>
           {orders.map((order) => (
             <tr key={order.id}>
-              <td>{order.completed_on}</td>
+              <td>{order.created_date}</td>
               <td>${order.total}</td>
-              <td>{order.payment_type?.obscured_num}</td>
+              <td>{order.payment_type.merchant_name}</td>
             </tr>
           ))}
         </Table>


### PR DESCRIPTION
Resolves #4 
When the user clicks Complete Order from the cart view, and then selects a payment type, and then clicks on the Complete Order button on that dialog, the order is marked as complete so that it shows up in the My Orders view and the cart is emptied.

##Changes

- data/orders.js
   - line 20: remove /complete
   - line 26: paymentTypeId as argument 
- data/payment-types.js
   - line 12/23: remove - from payment-types
- pages/cart.js
   - formatting
   - line 36: adding payment object for JSON
- pages/my-orders.js
   - formatting
   - line 15-46: adding fetch calls and functionality to calculate total and 
     retrieve payment type
   - line 57/59: change property names

##Testing

- [x] make sure API debugger is running
- [x] login to Bangazon
- [x] navigate to cart
- [x] click complete order and add a payment type
- [x] page should navigate to My Orders
- [x] order should show up in My Orders with the total cost and payment
- [x] navigate back to cart and make sure cart was emptied