### PR TITLE
Empty Order Interaction Bug-Fixes

### DIFF
--- a/components/order/form-modal.js
+++ b/components/order/form-modal.js
@@ -1,23 +1,46 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import Modal from "../modal"
 
 export default function CompleteFormModal({ showModal, setShowModal, paymentTypes, completeOrder }) {
-  const [selectedPayment, setSelectedPayment] = useState(0)
+  const [selectedPayment, setSelectedPayment] = useState("0")
+  const [showError, setShowError] = useState(false)
+
   return (
     <Modal showModal={showModal} setShowModal={setShowModal} title="Complete Order">
-      <div className="select">
-        <select value={selectedPayment} onChange={(event) => setSelectedPayment(event.target.value)}>
-          <option>Select a payment type to complete your order</option>
-          {
-            paymentTypes.map(pt => <option key={pt.id} value={pt.id}>{pt.merchant_name} {pt.obscured_num}</option>)
-          }
+      <div className="select" style={{ height: showError ? "50px" : "" }}>
+        <select
+          value={selectedPayment}
+          onChange={(event) => {
+            setSelectedPayment(event.target.value)
+            if (event.target.value != "0") {
+              setShowError(false)
+            }
+          }}>
+          <option value="0">Select a payment type to complete your order</option>
+          {paymentTypes.map((pt) => (
+            <option key={pt.id} value={pt.id}>
+              {pt.merchant_name} {pt.obscured_num}
+            </option>
+          ))}
         </select>
+        {showError && <p className="help is-danger">Please select a payment type</p>}
       </div>
       <>
-        <button className="button is-success" onClick={() => completeOrder(selectedPayment)}>Complete Order</button>
-        <button className="button" onClick={() => setShowModal(false)}>Cancel</button>
+        <button
+          className="button is-success"
+          onClick={() => {
+            if (selectedPayment != "0") {
+              completeOrder(selectedPayment)
+            } else {
+              setShowError(true)
+            }
+          }}>
+          Complete Order
+        </button>
+        <button className="button" onClick={() => setShowModal(false)}>
+          Cancel
+        </button>
       </>
     </Modal>
-
   )
 }

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -1,13 +1,13 @@
-import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
-import CardLayout from '../components/card-layout'
-import Layout from '../components/layout'
-import Navbar from '../components/navbar'
-import CartDetail from '../components/order/detail'
-import CompleteFormModal from '../components/order/form-modal'
-import { completeCurrentOrder, getCart } from '../data/orders'
-import { getPaymentTypes } from '../data/payment-types'
-import { removeProductFromOrder, removeAllProductsFromOrder } from '../data/products'
+import { useRouter } from "next/router"
+import { useEffect, useState } from "react"
+import CardLayout from "../components/card-layout"
+import Layout from "../components/layout"
+import Navbar from "../components/navbar"
+import CartDetail from "../components/order/detail"
+import CompleteFormModal from "../components/order/form-modal"
+import { completeCurrentOrder, getCart } from "../data/orders"
+import { getPaymentTypes } from "../data/payment-types"
+import { removeProductFromOrder, removeAllProductsFromOrder } from "../data/products"
 
 export default function Cart() {
   const [cart, setCart] = useState({})
@@ -34,14 +34,13 @@ export default function Cart() {
 
   const completeOrder = (paymentTypeId) => {
     const payment = { payment_type: paymentTypeId }
-    completeCurrentOrder(cart.id, payment)
-      .then(() => router.push("/my-orders"))
+    completeCurrentOrder(cart.id, payment).then(() => router.push("/my-orders"))
   }
 
   const removeProduct = (productId) => {
     removeProductFromOrder(productId).then(refresh)
   }
-  
+
   const removeAllProduct = () => {
     removeAllProductsFromOrder().then(refresh)
   }
@@ -54,13 +53,29 @@ export default function Cart() {
         paymentTypes={paymentTypes}
         completeOrder={completeOrder}
       />
-      <CardLayout title="Your Current Order">
-        <CartDetail cart={cart} removeProduct={removeProduct} />
-        <>
-          <a className="card-footer-item" onClick={() => setShowCompleteForm(true)}>Complete Order</a>
-          <a className="card-footer-item"onClick={() => removeAllProduct()}>Delete Order</a>
-        </>
-      </CardLayout>
+      {cart.products && cart.products.length > 0 ? (
+        <CardLayout title="Your Current Order">
+          <CartDetail cart={cart} removeProduct={removeProduct} />
+          <>
+            <a className="card-footer-item" onClick={() => setShowCompleteForm(true)}>
+              Complete Order
+            </a>
+            <a className="card-footer-item" onClick={() => removeAllProduct()}>
+              Delete Order
+            </a>
+          </>
+        </CardLayout>
+      ) : (
+        <div className="columns is-centered is-vcentered">
+          <div className="column is-6">
+            <div className="card">
+              <header className="card-header">
+                <h3 className="card-header-title">Your Current Order Is Empty</h3>
+              </header>
+            </div>
+          </div>
+        </div>
+      )}
     </>
   )
 }


### PR DESCRIPTION
This PR changes three issues:
- completing an order without any payment type is no longer possible
- completing an order that doesn’t exist is no longer possible
- deleting an order that doesn’t exist is no longer possible

## Changes

- `/pages/cart.js`
  - created a condition that checks whether or not the user has an active order
- `/components/order/form-modal.js`
  - added a warning for when the user attempts to complete an order without a payment type selected.


## Testing

To test this code, make sure that you are in the most recent versions of the `bugfix/empty-order` branch on your client-side, and the `development` branch on your API-side.

- [x] Start the server.
- [x] Start the client, and open `http://localhost:3000` in your browser.
- [x] Navigate to the **Cart** page (`/cart`).
- [x] If necessary, delete all items from the active order by clicking the "**Delete Order**" button.
- [x] Verify that the page now shows "**Your Current Order Is Empty**". See below:

<img width="474" alt="Screen Shot" src="https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/assets/147445675/23016fc3-f09d-4986-87a6-815f1c4dbe2e">

- [x] Next, create a newly active order. One way you can do this is by navigating to any product and clicking "**Add to Cart**".
- [x] Once your order contains some items again, click on the "**Complete Order**" button, back on the **Cart** page.
  You should be prompted with a modal asking to confirm your payment type.
- [x] In the dropdown, leave it set to "Select a payment type to complete your order", and attempt to complete the order, by clicking the "**Complete Order**" button.
- [x] Verify that, rather than completing the order, it instead shows a warning, stating "Please select a payment type". See below:

<img width="636" alt="Screen Shot" src="https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/assets/147445675/9b4810bf-13b3-4e3c-b08e-9713eeffd05e">
