### PR TITLE
Order History Page Fail Bug-Fix

### DIFF
--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -27,7 +27,7 @@ export default function Orders() {
         })
 
         Promise.all(fetchPaymentTypes).then((ordersWithData) => {
-          const ordersWithPaymentTypes = ordersWithData.filter((order) => order.paymentType !== null)
+          const ordersWithPaymentTypes = ordersWithData.filter((order) => order.payment_type !== null)
           const ordersDataTotal = ordersWithPaymentTypes.map((order) => {
             let total = 0
             if (order.lineitems) {


### PR DESCRIPTION
This PR solves the problem of the **Order History** page failing to load if there is a currently active order.

## Changes

- `/pages/my-orders.js`
  - changed attempting the access of `.paymentType` to `.payment_type`


## Testing

To test this code, make sure that you are in the most recent versions of the [`bugfix/order-history-filtering`](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/tree/bugfix/order-history-filtering) branch on your client-side, and the [`development`](https://github.com/NSS-Day-Cohort-68/bangazon-api-bangazon-team-1-api/tree/development) branch on your API-side.

- [x] Start the server.
- [x] Start the client, and open [`http://localhost:3000`](http://localhost:3000) in your browser.
- [x] Navigate to the **Cart** page ([`/cart`](http://localhost:3000/cart)).
- [x] Ensure that there are some items in your cart.
- [x] If there are no items in your cart, navigate to any product, and click "**Add to Cart**"
- [x] Once you've ensured you have an active order, by verifying that your cart contains at least one item, navigate to the **Order History** ([`/my-orders`](http://localhost:3000/my-orders)) page.
- [x] Verify that the page loads, with no client-visible errors.

## Related Issues

- #2