### PR TITLE
Payment Type Creation, Expiration Date Functionality

### DIFF
--- a/components/payments/payment-modal.js
+++ b/components/payments/payment-modal.js
@@ -5,6 +5,8 @@ import Modal from "../modal"
 export default function AddPaymentModal({ showModal, setShowModal, addNewPayment }) {
   const merchantNameInput = useRef()
   const acctNumInput = useRef()
+  const expDateInput = useRef()
+
   return (
     <Modal showModal={showModal} setShowModal={setShowModal} title="Add New Payment Method">
       <>
@@ -20,13 +22,20 @@ export default function AddPaymentModal({ showModal, setShowModal, addNewPayment
           label="Account Number"
           refEl={acctNumInput}
         />
+        <Input
+          id="expDate"
+          type="date"
+          label="Expiration Date"
+          refEl={expDateInput}
+        />
       </>
       <>
         <button
           className="button is-success"
           onClick={() => addNewPayment({
-            acctNumber: acctNumInput.current.value,
-            merchant: merchantNameInput.current.value
+            merchant: merchantNameInput.current.value.trim(),
+            acctNumber: acctNumInput.current.value.trim(),
+            expiration_date: expDateInput.current.value
           })}
         >Add Payment Method</button>
         <button className="button" onClick={() => setShowModal(false)}>Cancel</button>

--- a/pages/payments.js
+++ b/pages/payments.js
@@ -23,7 +23,7 @@ export default function Payments() {
   }, [])
 
   const addNewPayment = (payment) => {
-    if (payment.merchant.trim() && payment.acctNumber.trim() && payment.expiration_date){
+    if (payment.merchant && payment.acctNumber && payment.expiration_date){
       addPaymentType(payment).then(() => {
         setShowModal(false)
         refresh()

--- a/pages/payments.js
+++ b/pages/payments.js
@@ -23,10 +23,12 @@ export default function Payments() {
   }, [])
 
   const addNewPayment = (payment) => {
-    addPaymentType(payment).then(() => {
-      setShowModal(false)
-      refresh()
-    })
+    if (payment.merchant.trim() && payment.acctNumber.trim() && payment.expiration_date){
+      addPaymentType(payment).then(() => {
+        setShowModal(false)
+        refresh()
+      })
+    }
   }
 
   const removePayment = (paymentId) => {


### PR DESCRIPTION
This PR allows the user to input an expiration date when creating a new payment type.

## Changes

- `/components/payments/payment-modal.js`
  - created an `expDateInput` reference
  - created a new input element for the expiration date
- `/pages/payments.js`
  - added a verification check to ensure no empty form fields 


## Testing

To test this code, make sure that you are in the most recent versions of the `feature/payment-expiration-date` branch on your client-side, and the `development` branch on your API-side.

- [x] Start the server.
- [x] Start the client, and open [`http://localhost:3000`](http://localhost:3000) in your browser.
- [x] Navigate to the **Payment Methods** page ([`/payments`](http://localhost:3000/payments)).
- [x] Click on the "Add new Payment Method" button.
- [x] A form to create a new payment method should appear. Verify that the form includes an "Expiration Date" field. See below:

<img width="635" alt="Screen Shot" src="https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/assets/147445675/ddae969a-d56d-43cd-8ab5-037378cd0849">

&#x200B;

- [x] Fill out the form, and click the "Add Payment Method" button.
- [x] Verify that the new payment type is successfully created. See below:

![Screen Recording](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/assets/147445675/0ef374bc-ffc9-4d27-a2ae-31605660b176)
