### PR TITLE
Feature: List Stores and Products

### DIFF
--- a/components/store/card.js
+++ b/components/store/card.js
@@ -1,21 +1,18 @@
-import Link from 'next/link'
+import Link from "next/link"
 
-export function StoreCard({ store, width= "is-half" }) {
+export function StoreCard({ store, width = "is-half", totalProducts }) {
   return (
     <div className={`column ${width}`}>
       <div className="card">
         <header className="card-header">
-          <p className="card-header-title">
-            {store.name}
-          </p>
+          <p className="card-header-title">{store.name}</p>
         </header>
         <div className="card-content">
           <p className="content">
             Owner: {store.seller.first_name} {store.seller.last_name}
           </p>
-          <div className="content">
-            {store.description}
-          </div>
+          <div className="content">{store.description}</div>
+          <p>Total Products: {totalProducts}</p>
         </div>
         <footer className="card-footer">
           <Link href={`stores/${store.id}`}>

--- a/pages/stores/index.js
+++ b/pages/stores/index.js
@@ -29,9 +29,13 @@ export default function Stores() {
       <div className="columns is-multiline">
         {stores.map((store) => {
           const filteredProducts = products.filter((product) => product.customer_id === store.seller.id)
+          let totalProducts = 0;
+          filteredProducts.forEach((product) => {
+            totalProducts += product.quantity;
+          });
           return (
             <div className="columns is-multiline">
-              <StoreCard store={store} key={store.id} totalProducts={filteredProducts.length } />
+              <StoreCard store={store} key={store.id} totalProducts={totalProducts } />
               <div className="columns is-multiline">
                 
                 {filteredProducts.map((filteredProduct) => (

--- a/pages/stores/index.js
+++ b/pages/stores/index.js
@@ -1,17 +1,24 @@
-import { useEffect, useState } from 'react'
-import Layout from '../../components/layout'
-import Navbar from '../../components/navbar'
-import { StoreCard } from '../../components/store/card'
-import { getStores } from '../../data/stores'
-
+import { useEffect, useState } from "react"
+import Layout from "../../components/layout"
+import Navbar from "../../components/navbar"
+import { StoreCard } from "../../components/store/card"
+import { getStores } from "../../data/stores"
+import { getProducts } from "../../data/products"
+import { ProductCard } from "../../components/product/card"
 
 export default function Stores() {
   const [stores, setStores] = useState([])
+  const [products, setProducts] = useState([])
 
   useEffect(() => {
-    getStores().then(data => {
+    getStores().then((data) => {
       if (data) {
         setStores(data)
+      }
+    })
+    getProducts().then((data) => {
+      if (data) {
+        setProducts(data)
       }
     })
   }, [])
@@ -20,11 +27,20 @@ export default function Stores() {
     <>
       <h1 className="title">Stores</h1>
       <div className="columns is-multiline">
-      {
-        stores.map(store => (
-          <StoreCard store={store} key={store.id} />
-        ))
-      }
+        {stores.map((store) => {
+          const filteredProducts = products.filter((product) => product.customer_id === store.seller.id)
+          return (
+            <div className="columns is-multiline">
+              <StoreCard store={store} key={store.id} totalProducts={filteredProducts.length } />
+              <div className="columns is-multiline">
+                
+                {filteredProducts.map((filteredProduct) => (
+                  <ProductCard product={filteredProduct} key={filteredProduct.id} />
+                ))}
+              </div>
+            </div>
+          )
+        })}
       </div>
     </>
   )


### PR DESCRIPTION
When on Stores page, list of store name, desc, owner, and total quantity of products for sale appear as well as all of the products.

Resolves #1 

**Review server side PR before this**

## Changes

- components/store/card.js: add total products count
- pages/stores/index.js: get and display products

## Testing

- [x] Run debugger
- [x] Make sure client side is running (make sure server-side is updated with the feature/list-stores branch)
- [x] Navigate to Stores page
- [x] Confirm that all stores show up with store name, owner, and description, as well as the product count.
- [x] All of the products for each store should show up as well

![Screenshot 2024-04-12 at 2 37 03 PM](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/assets/149907329/c1ec9052-659a-4060-b2a7-48496c7134a7)

