### PR TITLE
Store Info on Profile Bug-Fix

### DIFF
--- a/components/store/card.js
+++ b/components/store/card.js
@@ -1,21 +1,21 @@
 import Link from "next/link"
 
-export function StoreCard({ store, width = "is-half", totalProducts }) {
+export function StoreCard({ favorite, width = "is-half", totalProducts }) {
   return (
     <div className={`column ${width}`}>
       <div className="card">
         <header className="card-header">
-          <p className="card-header-title">{store.name}</p>
+          <p className="card-header-title">{favorite.store.name}</p>
         </header>
         <div className="card-content">
           <p className="content">
-            Owner: {store.seller.first_name} {store.seller.last_name}
+            Owner: {favorite.seller.first_name} {favorite.seller.last_name}
           </p>
-          <div className="content">{store.description}</div>
-          <p>Total Products: {totalProducts}</p>
+          <div className="content">{favorite.store.description}</div>
+          {/*//TODO: <p>Total Products: {totalProducts}</p> */}
         </div>
         <footer className="card-footer">
-          <Link href={`stores/${store.id}`}>
+          <Link href={`stores/${favorite.store.id}`}>
             <a className="card-footer-item">View Store</a>
           </Link>
         </footer>

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -24,7 +24,7 @@ export default function Profile() {
         <div className="columns is-multiline">
           {
             profile.favorites?.map(favorite => (
-              <StoreCard store={favorite} key={favorite.id} width="is-one-third" />
+              <StoreCard favorite={favorite} key={favorite.id} width="is-one-third" />
             ))
           }
         </div>


### PR DESCRIPTION
This PR allows the user to see the valid store information on their profile, and navigate the correct store view.

## Changes

- `/pages/profile.js`
  - passed in the entire `favorite` result to the `StoreCard`, rather than just the `store` property
- `/components/store/card.js`
  - modified the `StoreCard` to show accurate info
  - added a "TODO" for the total products


## Testing

To test this code, make sure that you are in the most recent versions of the `bugfix/favorite-store` branch on your client-side, and the `development` branch on your API-side.

- [x] Start the server.
- [x] Start the client, and open [`http://localhost:3000`](http://localhost:3000) in your browser.
- [x] Navigate to the **Profile** page ([`/profile`](http://localhost:3000/profile)).
- [x] Verify that the store description is visible for each favorited store.
- [x] Click on the store, and verify that you are navigated to the correct page.
