### PR TITLE
Stores List Page Fail Bug-Fix

### DIFF
--- a/components/store/card.js
+++ b/components/store/card.js
@@ -1,6 +1,30 @@
 import Link from "next/link"
 
-export function StoreCard({ favorite, width = "is-half", totalProducts }) {
+export function StoreCard({ store, favorite, width = "is-half", totalProducts, listView }) {
+  if (listView) {
+    return (
+      <div className={`column ${width}`}>
+        <div className="card">
+          <header className="card-header">
+            <p className="card-header-title">{store.name}</p>
+          </header>
+          <div className="card-content">
+            <p className="content">
+              Owner: {store.seller.first_name} {store.seller.last_name}
+            </p>
+            <div className="content">{store.description}</div>
+            {totalProducts && <p>Total Products: {totalProducts}</p>}
+          </div>
+          <footer className="card-footer">
+            <Link href={`stores/${store.id}`}>
+              <a className="card-footer-item">View Store</a>
+            </Link>
+          </footer>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className={`column ${width}`}>
       <div className="card">
@@ -12,7 +36,7 @@ export function StoreCard({ favorite, width = "is-half", totalProducts }) {
             Owner: {favorite.seller.first_name} {favorite.seller.last_name}
           </p>
           <div className="content">{favorite.store.description}</div>
-          {/*//TODO: <p>Total Products: {totalProducts}</p> */}
+          {totalProducts && <p>Total Products: {totalProducts}</p>}
         </div>
         <footer className="card-footer">
           <Link href={`stores/${favorite.store.id}`}>

--- a/pages/stores/index.js
+++ b/pages/stores/index.js
@@ -34,10 +34,10 @@ export default function Stores() {
             totalProducts += product.quantity;
           });
           return (
-            <div className="columns is-multiline">
-              <StoreCard store={store} key={store.id} totalProducts={totalProducts } />
+            <div className="columns is-multiline" key={store.id}>
+              <StoreCard store={store} key={store.id} totalProducts={totalProducts} listView={true}/>
               <div className="columns is-multiline">
-                
+
                 {filteredProducts.map((filteredProduct) => (
                   <ProductCard product={filteredProduct} key={filteredProduct.id} />
                 ))}


### PR DESCRIPTION
This PR solves the problem of the **Stores** page failing to load.

## Changes

- `/pages/stores/index.js`
  - passed a `listView` property to the `StoreCard`
- `/components/store/card.js`
  - added correct accessing logic for when loading the `listView`

## Testing

To test this code, make sure that you are in the most recent versions of the `bugfix/stores-list` branch on your client-side, and the `development` branch on your API-side.

- [ ] Start the server.
- [ ] Start the client, and open [`http://localhost:3000`](http://localhost:3000) in your browser.
- [ ] Navigate to the **Stores** page ([`/stores`](http://localhost:3000/stores)).
- [ ] Verify that the page loads, with no visible errors.

## Related Issues

- Ticket [#13](https://github.com/NSS-Day-Cohort-68/bangazon-client-bangazon-team-1-client/issues/13)